### PR TITLE
feat: Implement amendment completion and mastery indicators

### DIFF
--- a/css/components/status-indicators.css
+++ b/css/components/status-indicators.css
@@ -1,0 +1,27 @@
+/* Styles for amendment status indicators on home page cards */
+.amendment-card-home {
+    position: relative; /* Ensures status indicator is positioned relative to the card */
+}
+
+.amendment-status {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    padding: 3px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.amendment-status.completed {
+    background-color: rgba(42, 157, 143, 0.2); /* Teal/Green background */
+    color: #2a9d8f; /* Teal/Green text/icon */
+}
+
+.amendment-status.mastered {
+    background-color: rgba(52, 152, 219, 0.2); /* Light blue background */
+    color: #3498db; /* Darker blue text/icon */
+}

--- a/css/main.css
+++ b/css/main.css
@@ -7,6 +7,7 @@
 @import url('layout/container.css');
 
 /* ==== Components ==== */
+@import url('components/status-indicators.css');
 @import url('components/progress-bar.css');
 @import url('components/buttons.css');
 @import url('components/cards.css');

--- a/js/script.js
+++ b/js/script.js
@@ -9,9 +9,6 @@ document.addEventListener('DOMContentLoaded', () => {
     amendmentStatus = JSON.parse(localStorage.getItem('amendmentStatus')) || {};
     
     
-    // Add CSS for amendment status indicators
-    addStatusStyles();
-    
     // Update amendment status indicators on home page
     updateAmendmentStatusIndicators();
     
@@ -378,6 +375,10 @@ let actionScores = JSON.parse(localStorage.getItem('userActionScores')) || {};
 let totalXP = parseInt(localStorage.getItem('totalUserXP')) || 0;
 let amendmentStatus = JSON.parse(localStorage.getItem('amendmentStatus')) || {};
 
+const AMENDMENT_XP = 50;
+const COMPLETED_PERCENTAGE = 0.80;
+const MASTERED_PERCENTAGE = 1.00;
+
 
 
 
@@ -722,40 +723,13 @@ function updateAmendmentStatusIndicators() {
             // Different icon and text based on status
             if (status === 'completed') {
                 statusDiv.innerHTML = '<i class="fas fa-check-circle"></i> <span>Completed</span>';
-                statusDiv.style.backgroundColor = 'rgba(42, 157, 143, 0.2)';
-                statusDiv.style.color = '#2a9d8f';
             } else if (status === 'mastered') {
                 statusDiv.innerHTML = '<i class="fas fa-star"></i> <span>Mastered</span>';
-                statusDiv.style.backgroundColor = 'rgba(233, 196, 106, 0.2)';
-                statusDiv.style.color = '#e9c46a';
             }
             
             card.appendChild(statusDiv);
         }
     });
-}
-
-// Add CSS for amendment status indicators
-function addStatusStyles() {
-    const style = document.createElement('style');
-    style.textContent = `
-        .amendment-status {
-            position: absolute;
-            top: 10px;
-            right: 10px;
-            padding: 3px 8px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: bold;
-            display: flex;
-            align-items: center;
-            gap: 5px;
-        }
-        .amendment-card-home {
-            position: relative;
-        }
-    `;
-    document.head.appendChild(style);
 }
 
 // Save quiz answers to localStorage


### PR DESCRIPTION
This commit introduces visual indicators on the home page for amendment completion (80% XP) and mastery (100% XP).

Key changes:
- Added global constants AMENDMENT_XP (set to 50), COMPLETED_PERCENTAGE (0.80), and MASTERED_PERCENTAGE (1.00) to js/script.js.
- Modified the updateAmendmentStatusIndicators function in js/script.js to display:
    - "Completed" status with a green theme and checkmark icon.
    - "Mastered" status with a blue theme and star icon.
- Refactored styling for these indicators from inline JavaScript styles to a dedicated CSS file (css/components/status-indicators.css) and imported it into main.css.
- The checkAmendmentStatus function now correctly utilizes these constants to determine and store the status of each amendment.

These changes allow you to easily see your progress for each amendment directly on the home page.