### PR TITLE
Fix progress badges on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,7 @@
         
     </div>
 
+    <script src="js/home.js"></script>
     <script src="js/awards.js"></script>
     <script>
         // Function to update the display based on current localStorage data
@@ -171,6 +172,11 @@
             // Render awards section if the awards system is loaded
             if (window.awardsSystem && window.awardsSystem.renderAwardsSection) {
                 window.awardsSystem.renderAwardsSection();
+            }
+
+            // Update amendment status indicators if available
+            if (typeof updateAmendmentStatusIndicators === 'function') {
+                updateAmendmentStatusIndicators();
             }
         }
 

--- a/js/home.js
+++ b/js/home.js
@@ -1,0 +1,37 @@
+// Home page logic for updating amendment status indicators
+
+// Load amendment status from localStorage and expose update function
+function updateAmendmentStatusIndicators() {
+    const amendmentStatus = JSON.parse(localStorage.getItem('amendmentStatus')) || {};
+
+    // Only run on pages with the amendments list
+    if (!document.querySelector('.amendments-list')) return;
+
+    const cards = document.querySelectorAll('.amendment-card-home');
+    cards.forEach(card => {
+        const amendmentLink = card.closest('a');
+        if (!amendmentLink) return;
+
+        const hrefMatch = amendmentLink.href.match(/amendment=(\d+)/);
+        if (!hrefMatch) return;
+
+        const amendmentNumber = hrefMatch[1];
+        const status = amendmentStatus[amendmentNumber];
+
+        const existingStatus = card.querySelector('.amendment-status');
+        if (existingStatus) existingStatus.remove();
+
+        if (status === 'completed' || status === 'mastered') {
+            const statusDiv = document.createElement('div');
+            statusDiv.className = `amendment-status ${status}`;
+            if (status === 'completed') {
+                statusDiv.innerHTML = '<i class="fas fa-check-circle"></i> <span>Completed</span>';
+            } else {
+                statusDiv.innerHTML = '<i class="fas fa-star"></i> <span>Mastered</span>';
+            }
+            card.appendChild(statusDiv);
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', updateAmendmentStatusIndicators);

--- a/js/script.js
+++ b/js/script.js
@@ -465,14 +465,17 @@ function checkQuiz() {
     if (window.awardsSystem && (score > previousScore || !actionScores[actionId])) {
         // If this is an improvement, only count the net new correct answers
         const correctCount = !actionScores[actionId] ? score / 10 : (score - previousScore) / 10;
-        
+
         window.awardsSystem.triggerAwardEvent('quizCompleted', amendmentNumber, {
-            correctCount: correctCount, 
+            correctCount: correctCount,
             totalQuestions: totalQuestions,
             isPerfect: score === maxScore,
             isImprovement: true
         });
     }
+
+    // Update completion status based on earned XP
+    checkAmendmentStatus(amendmentNumber);
 }
 
 function checkScenario(selectedAnswer) {
@@ -526,6 +529,9 @@ function checkScenario(selectedAnswer) {
             isCorrect: true
         });
     }
+
+    // Update completion status based on earned XP
+    checkAmendmentStatus(amendmentNumber);
 }
 
 

--- a/tests/home.test.js
+++ b/tests/home.test.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+
+function setupDocument(status) {
+  const card = {
+    children: [],
+    appendChild(node) { this.children.push(node); },
+    querySelector(sel) {
+      if (sel === '.amendment-status') {
+        return this.children.find(c => c.className && c.className.includes('amendment-status')) || null;
+      }
+      return null;
+    },
+    closest(tag) {
+      if (tag === 'a') return { href: 'amendments.html?amendment=5' };
+      return null;
+    }
+  };
+
+  const documentStub = {
+    querySelector(sel) { return sel === '.amendments-list' ? {} : null; },
+    querySelectorAll(sel) { return sel === '.amendment-card-home' ? [card] : []; },
+    createElement() { return { className: '', innerHTML: '' }; },
+    addEventListener(event, cb) { if (event === 'DOMContentLoaded') cb(); }
+  };
+
+  global.document = documentStub;
+  global.localStorage = {
+    getItem(key) { return key === 'amendmentStatus' ? JSON.stringify(status) : null; }
+  };
+
+  delete require.cache[require.resolve('../js/home.js')];
+  require('../js/home.js');
+
+  return card;
+}
+
+module.exports.testAddsCompletedBadge = function() {
+  const card = setupDocument({ 5: 'completed' });
+  const status = card.children[0];
+  assert(status.className.includes('completed'));
+};
+
+module.exports.testAddsMasteredBadge = function() {
+  const card = setupDocument({ 5: 'mastered' });
+  const status = card.children[0];
+  assert(status.className.includes('mastered'));
+};

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -20,7 +20,7 @@ function runLoader(query) {
 
   global.document = documentStub;
   global.window = { location: { search: query } };
-  global.amendmentData = { 5: { title: 'Fifth Amendment' } };
+  global.amendmentData = { 1: { title: 'First' }, 5: { title: 'Fifth Amendment' } };
 
   delete require.cache[require.resolve('../js/loader.js')];
   require('../js/loader.js');
@@ -31,4 +31,9 @@ function runLoader(query) {
 module.exports.testSetsAmendmentAttribute = function() {
   const result = runLoader('?amendment=5');
   assert.strictEqual(result, 5);
+};
+
+module.exports.testDefaultsToOne = function() {
+  const result = runLoader('');
+  assert.strictEqual(result, 1);
 };


### PR DESCRIPTION
## Summary
- add home.js to update amendment status indicators on the landing page
- include home.js in index.html and refresh indicators when the page loads or regains focus
- trigger status checks after quiz and scenario submission
- expand unit tests to cover home page progress and loader defaults

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f7b81467c832a994bec667d945a78